### PR TITLE
Add getnews.tech

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -158,6 +158,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [wego](https://github.com/schachmat/wego) - Get the weather right in your browser or your console.
 - [mapscii](https://github.com/rastapasta/mapscii) - Terminal Map Viewer - the whole world in your console!
 - [website-popup-cli](https://github.com/sindresorhus/website-popup-cli) - Quickly watch a window in a pop up window without closing or opening another full screen window.
+- [getnews.tech](https://github.com/omgimanerd/getnews.tech) - Fetch news headlines from various news outlets in your terminal.
 
 ### macOS
 


### PR DESCRIPTION
This is a utility that allows developers to quickly fetch news headlines from the terminal via the `curl` command, similar to wttr.in.