### PR TITLE
Added curate-pkg

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -252,7 +252,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [localtunnel](https://github.com/localtunnel/localtunnel) - Exposes your localhost to the world for easy testing and sharing.
 - [mosh](https://mosh.org/) - Remote SSH client that allows roaming with intermittent connectivity.
 - [ngrok](https://ngrok.com/) - secure introspectable tunnels to localhost.
-- [serveo](https://serveo.net/) - Expose local servers to the internet using only a SSH client. 
+- [serveo](https://serveo.net/) - Expose local servers to the internet using only a SSH client.
 - [seashells.io](https://seashells.io/) - Pipe output from command-line programs to the web in real-time.
 - [teleconsole](https://www.teleconsole.com/) - Share your UNIX terminal in seconds.
 - [tmate.io](https://tmate.io/) - Instant terminal (tmux) sharing.
@@ -322,6 +322,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [birthday](https://github.com/IonicaBizau/birthday) - Know when a friend's birthday is coming.
 - [cowsay](https://github.com/tnalpgge/rank-amateur-cowsay) - You can [install with homebrew](http://brewformulas.org/Cowsay).
 - [cgasm](https://github.com/bnagy/cgasm) - A tool that gives x86 assembly documentation. It is pronounced "SeekAzzem".
+- [curate-pkg](https://github.com/andrei-pavel/curate-pkg) - Keeps a package configuration, great for when reinstalling Linux
 - [detect-indent-cli](https://github.com/sindresorhus/detect-indent-cli) - Detect the indentation of code.
 - [emoj](https://github.com/sindresorhus/emoj) - Find relevant emoji from text on the command-line.
 - [emoji-finder](https://github.com/dematerializer/emoji-finder) - Quickly find and copy emoji to the clipboard via the command-line

--- a/readme.md
+++ b/readme.md
@@ -315,6 +315,9 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [sparkly-cli](https://github.com/sindresorhus/sparkly-cli) - Generate sparklines ▁▂▃▅▂▇..
 - [JackPaper](https://github.com/jackel27/jackpaper) - Pull random/queried images from unplash.com and apply to your desktop wallpaper.
 
+## Package Management
+- [curate-pkg](https://github.com/andrei-pavel/curate-pkg) - Keeps a package configuration, great for when reinstalling Linux.
+
 ## Other
 
 - [app-path-cli](https://github.com/sindresorhus/app-path-cli) - Get the path to an app (macOS).
@@ -322,7 +325,6 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [birthday](https://github.com/IonicaBizau/birthday) - Know when a friend's birthday is coming.
 - [cowsay](https://github.com/tnalpgge/rank-amateur-cowsay) - You can [install with homebrew](http://brewformulas.org/Cowsay).
 - [cgasm](https://github.com/bnagy/cgasm) - A tool that gives x86 assembly documentation. It is pronounced "SeekAzzem".
-- [curate-pkg](https://github.com/andrei-pavel/curate-pkg) - Keeps a package configuration, great for when reinstalling Linux
 - [detect-indent-cli](https://github.com/sindresorhus/detect-indent-cli) - Detect the indentation of code.
 - [emoj](https://github.com/sindresorhus/emoj) - Find relevant emoji from text on the command-line.
 - [emoji-finder](https://github.com/dematerializer/emoji-finder) - Quickly find and copy emoji to the clipboard via the command-line


### PR DESCRIPTION
Very excited about this one. It's written in bash, it operates on a user-modified JSON configuration which contains:
- apt keys e.g. `https://dl.google.com/linux/linux_signing_key.pub`
- apt repositories e.g. `multiverse`
- apt sources e.g. `deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main`
- apt installs e.g. `google-chrome`
- apt purges e.g. `firefox`
- any custom command package-management-related e.g. `ubuntu-drivers autoinstall`
- ANYTHING `wget`-able e.g. `https://dl.pstmn.io/download/latest/linux?arch=64` (archives or `.deb`)
These are all `apt`-based examples, but it also supports `eopkg` and I would like to continuously add support for other package managers.
The point is to get updates for everything you put in here with just the run of a command and account for each of them only once. What do you think?
