### PR TITLE
Add alex

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -363,6 +363,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [google-wifi-status](https://github.com/joelgeorgev/google-wifi-status) - A Node.js CLI app that displays status of your Google Wifi / OnHub router.
 - [calories](https://github.com/zupzup/calories) - Calories and weight tracker.
 - [trino](https://github.com/eneserdogan/trino) - Trino CLI allows a quick and easy translation of words and phrases entered in the command line.
+- [alex](https://github.com/wooorm/alex) - This enhances texts with checking for insensitive, inconsiderate writing by catching many possible offences.
 
 ## Other Awesome Lists
 


### PR DESCRIPTION
Hej, two things I’m not quite sure enough:

1. The category.

    It may get lost by adding it  to »Other«. But I didn’t find another appropriate category.

    Maybe it would make sense to check if the whole list contains other apps to open a new category with the name »Writing«.

2. The link.
    
    Should we link to the Github page or to the [website](http://alexjs.com/)?

