### PR TITLE
Add papis to productivity section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -164,6 +164,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [Buku](https://github.com/jarun/Buku) - Powerful command-line bookmark manager
 - [googler](https://github.com/jarun/googler) - Google Search, Google Site Search, Google News from the terminal
 - [calcurse](http://calcurse.org/) - Calcurse, a calendar and scheduling application for the command line.
+- [papis](http://github.com/alejandrogallo/papis) - Powerful and extensible document and bibliography manager.
 
 ## Utilities
 


### PR DESCRIPTION
I have added the project `papis` to the productivity list.
`papis` is a way of organizing documents (books, papers, even music and videos)
in a very simple way. 
It is designed to be modular (write scripts like in `git`), play well with
tools like `git` and to make people feel that they can take full control of their libraries
(in contrast with `zotero`, `mendeley` and the like).

It is specially well-suited for authors and researchers.

- Big disclaimer: I am the main contributor.
- Why: It is currently being used by some people and there is no similar software in the list
currently.