### PR TITLE
Add undollar

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -364,6 +364,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [calories](https://github.com/zupzup/calories) - Calories and weight tracker.
 - [trino](https://github.com/eneserdogan/trino) - Trino CLI allows a quick and easy translation of words and phrases entered in the command line.
 - [alex](https://github.com/wooorm/alex) - This enhances texts with checking for insensitive, inconsiderate writing by catching many possible offences.
+- [undollar](https://github.com/ImFeelingDucky/undollar) - undollar strips the '$' preceding copy-pasted terminal commands.
 
 ## Other Awesome Lists
 


### PR DESCRIPTION
[undollar](https://github.com/ImFeelingDucky/undollar) makes copy-pasting commands from the internet easier. If the command includes a leading dollar sign, undollar removes it and runs the rest of the command.