### PR TITLE
Added jin to Productivity

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -165,6 +165,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [calcurse](http://calcurse.org/) - Calcurse, a calendar and scheduling application for the command line.
 - [cash-cli](https://github.com/xxczaki/cash-cli) - Convert 32 currencies from the command line!
 - [papis](http://github.com/alejandrogallo/papis) - Powerful and extensible document and bibliography manager.
+- [jin](https://github.com/Splode/jin) - Take and organize simple notes without ever leaving the command line.
 
 ## Utilities
 


### PR DESCRIPTION
Added [**jin**](https://github.com/Splode/jin), a command-line application for taking simple notes without ever leaving the terminal. **jin** allows you to take and organize simple notes without ever leaving the command line. Use it to capture ideas, track tasks, and reference code snippets with straightforward and intuitive commands.