### PR TITLE
Adding spotydrive to Entertainment category

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -79,6 +79,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [football-cli](https://github.com/ManrajGrover/football-cli) - Get live scores, fixtures, standings of almost every football competition/league in your terminal.
 - [pockyt](https://github.com/arvindch/pockyt) - Read, Manage, and Automate your [Pocket](https://getpocket.com) collection.
 - [splash-cli](https://github.com/rawnly/splash-cli) - Beautiful wallpapers from [unsplash](http://unsplash.com)
+- [spotydrive](https://github.com/emersonsoares/spotydrive) - Sync your favorite Spotify playlists offline as mp3 files.
 
 ### Social Media
 


### PR DESCRIPTION
Hey, I would like to suggest **[spotydrive](https://github.com/emersonsoares/spotydrive)**. 

It's a tool created by me, from my necessity to listen to my Spotify playlists even when I'm not on my smartphone. Sometimes when I'm on our ~hippie~ road trips with my VW Fusca and my girlfriend, a USB stick with some old good mp3 media is enough. 

It's a work in progress, need a lot of improvements, but it's good for a first version. 

👊 