### PR TITLE
Added PharTools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -188,6 +188,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [getnews.tech](https://github.com/omgimanerd/getnews.tech) - Fetch news headlines from various news outlets in your terminal.
 - [has](https://github.com/kdabir/has) - Checks for the presence of various commands and their versions on the path.
 - [decktape](https://github.com/astefanutti/decktape) - PDF exporter for HTML presentations.
+- [phartools](https://github.com/EvolSoft/PharTools) - A powerful PHP-CLI tool to manage phar (PHP-Archive) files
 
 ### macOS
 


### PR DESCRIPTION
PharTools is a powerful PHP-CLI tool to manage phar (PHP-Archive) files.