### PR TITLE
Adds carbon-now-cli

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -188,6 +188,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [getnews.tech](https://github.com/omgimanerd/getnews.tech) - Fetch news headlines from various news outlets in your terminal.
 - [has](https://github.com/kdabir/has) - Checks for the presence of various commands and their versions on the path.
 - [decktape](https://github.com/astefanutti/decktape) - PDF exporter for HTML presentations.
+- [carbon-now-cli](https://github.com/mixn/carbon-now-cli) - 🎨 Beautiful images of your code — from right inside your terminal.
 
 ### macOS
 


### PR DESCRIPTION
### 🎨 carbon-now-cli
#### Beautiful images of your code — from right inside your terminal.

##### Link

[https://github.com/mixn/carbon-now-cli](https://github.com/mixn/carbon-now-cli)

##### Why it should be included 

The feedback for this tool I made was quite overwhelming and the tool itself seems quite useful to many. So I thought it might be a good fit for this list. :)