### PR TITLE
Add Discharge

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -143,6 +143,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [add-gitignore](https://github.com/TejasQ/add-gitignore) - Interactive CLI that generates a .gitignore for your project based on your needs.
 - [mevn-cli](http://github.com/madlabsinc/mevn-cli) - CLI tool for the MEVN stack.
 - [scaffold-static](https://github.com/jamesgeorge007/scaffold-static) - Static site generator for vanila JS.
+- [Discharge](https://github.com/brandonweiss/discharge) - Simple, easy way to deploy static websites to Amazon S3.
 
 ### Mobile Development
 


### PR DESCRIPTION
[Discharge](https://github.com/brandonweiss/discharge) is, as far as I’m aware, the easiest way to deploy static websites to Amazon S3. It can also configure an SSL certificate and distribute the site via CloudFront, all without having to know anything about AWS. I spent hours poring over AWS’s terrible docs so no one else would have to. There is also a prompt-based UI to help you configure it. And it’s very well documented.

Thanks for considering!