### PR TITLE
Update URL for Terminal velocity. Add sncli to Productivity.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -190,8 +190,8 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [cash-cli](https://github.com/xxczaki/cash-cli) - Convert 32 currencies from the command line!
 - [papis](http://github.com/alejandrogallo/papis) - Powerful and extensible document and bibliography manager.
 - [Terminal velocity](https://terminal-velocity-notes.github.io/terminal_velocity/) - A fast note-taking app for the UNIX terminal.
-- [sncli](https://github.com/insanum/sncli) - A simple Python application that gives you access to your Simplenote account via the command line.
 - [eureka](https://github.com/simeg/eureka) - Store your ideas without leaving the terminal.
+- [sncli](https://github.com/insanum/sncli) - A simple Python application that gives you access to your Simplenote account via the command line.
 
 ## Utilities
 

--- a/readme.md
+++ b/readme.md
@@ -190,7 +190,8 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [calcurse](http://calcurse.org/) - Calcurse, a calendar and scheduling application for the command line.
 - [cash-cli](https://github.com/xxczaki/cash-cli) - Convert 32 currencies from the command line!
 - [papis](http://github.com/alejandrogallo/papis) - Powerful and extensible document and bibliography manager.
-- [Terminal velocity](https://vhp.github.io/terminal_velocity/) - A fast note-taking app for the UNIX terminal.
+- [Terminal velocity](https://terminal-velocity-notes.github.io/terminal_velocity/) - A fast note-taking app for the UNIX terminal.
+- [sncli](https://github.com/insanum/sncli) - A simple Python application that gives you access to your Simplenote account via the command line.
 
 ## Utilities
 


### PR DESCRIPTION
**Update**

[Terminal velocity](https://terminal-velocity-notes.github.io/terminal_velocity/)

I noticed the URL currently provided no longer works. New URL is provided above.

**Add**

[sncli](https://github.com/insanum/sncli) - Simplenote Command Line Interface

sncli is a Python application that gives you access to your Simplenote account via the command line. You can access your notes via a customizable console GUI that implements vi-like keybinds or via a simple command line interface that you can script.

Very handy and configurable... I wouldn't go a day without it.

Does not have a LICENSE file provided on the repo, but upon further inspection it is in fact licensed under the MIT license.

Thanks!