### PR TITLE
Add simplehttp

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -145,7 +145,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [mevn-cli](http://github.com/madlabsinc/mevn-cli) - CLI tool for the MEVN stack.
 - [scaffold-static](https://github.com/jamesgeorge007/scaffold-static) - Static site generator for vanila JS.
 - [Discharge](https://github.com/brandonweiss/discharge) - Simple, easy way to deploy static websites to Amazon S3.
-- [simplehttp](https://github.com/snwfdhmp) Most simplest and direct way to start serving a local directory over HTTP from CLI.
+- [simplehttp](https://github.com/snwfdhmp/simplehttp) Most simplest and direct way to start serving a local directory over HTTP from CLI.
 
 ### Mobile Development
 

--- a/readme.md
+++ b/readme.md
@@ -145,6 +145,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [mevn-cli](http://github.com/madlabsinc/mevn-cli) - CLI tool for the MEVN stack.
 - [scaffold-static](https://github.com/jamesgeorge007/scaffold-static) - Static site generator for vanila JS.
 - [Discharge](https://github.com/brandonweiss/discharge) - Simple, easy way to deploy static websites to Amazon S3.
+- [simplehttp](https://github.com/snwfdhmp) Most simplest and direct way to start serving a local directory over HTTP from CLI.
 
 ### Mobile Development
 


### PR DESCRIPTION
[package link](https://github.com/snwfdhmp/simplehttp)

I think this package can be useful for web developers when they need to quickly serve some files over http from CLI without wanting to configure at least an Apache or NGINX.