### PR TITLE
Add newsboat

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -74,6 +74,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [football-cli](https://github.com/ManrajGrover/football-cli) - Get live scores, fixtures, standings of almost every football competition/league in your terminal.
 - [pockyt](https://github.com/arvindch/pockyt) - Read, Manage, and Automate your [Pocket](https://getpocket.com) collection.
 - [splash-cli](https://github.com/rawnly/splash-cli) - Beautiful wallpapers from [unsplash](http://unsplash.com).
+- [newsboat](https://github.com/newsboat/newsboat) - An extendable RSS feed reader for text terminals.
 
 ### Music
 


### PR DESCRIPTION
Implements #105

#### New App Submission

**App name:**
Newsboat

**Repo or homepage link:**
[repo](https://github.com/newsboat/newsboat)

**Description:**
An extendable RSS feed reader for text terminals.

**Why you think it's awesome:**
Very flexible RSS feed app. I use it for watching youtube (a channels uploads are available as RSS feed, which I then watch in vlc), as well as downloading podcasts.