### PR TITLE
Add td-cli to productivity

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -200,7 +200,6 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [calcurse](http://calcurse.org/) - Calcurse, a calendar and scheduling application for the command line.
 - [papis](http://github.com/alejandrogallo/papis) - Powerful and extensible document and bibliography manager.
 - [mdp](https://github.com/visit1985/mdp) - A command-line based markdown presentation tool.
-- [td-cli](https://github.com/darrikonn/td-cli) - A todo command-line manager to organize and manage your todos across multiple projects.
 
 ### Time Tracking
 
@@ -215,6 +214,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [Terminal velocity](https://terminal-velocity-notes.github.io/terminal_velocity/) - A fast note-taking app for the UNIX terminal.
 - [eureka](https://github.com/simeg/eureka) - Store your ideas without leaving the terminal.
 - [sncli](https://github.com/insanum/sncli) - A simple Python application that gives you access to your Simplenote account via the command line.
+- [td-cli](https://github.com/darrikonn/td-cli) - A todo command-line manager to organize and manage your todos across multiple projects.
 
 ### Finance
 

--- a/readme.md
+++ b/readme.md
@@ -200,6 +200,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [calcurse](http://calcurse.org/) - Calcurse, a calendar and scheduling application for the command line.
 - [papis](http://github.com/alejandrogallo/papis) - Powerful and extensible document and bibliography manager.
 - [mdp](https://github.com/visit1985/mdp) - A command-line based markdown presentation tool.
+- [td-cli](https://github.com/darrikonn/td-cli) - A todo command-line manager to organize and manage your todos across multiple projects.
 
 ### Time Tracking
 


### PR DESCRIPTION
## td-cli

### Link
https://github.com/darrikonn/td-cli

### Description
**td-cli** is a command line todo manager, 
where you can organize and manage your todos across multiple projects

### Why?
**td-cli** allows you to group your todos based on your projects and helps you keep your todos well organized and well structured.
**td-cli** also has an awesome interactive mode which speeds up the whole process!

### How to install
```bash
pip3 install td-cli
```