### PR TITLE
Add npm-check-updates

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -157,6 +157,8 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [simplehttp](https://github.com/snwfdhmp/simplehttp) - Most simplest and direct way to start serving a local directory over HTTP from CLI.
 - [shell2http](https://github.com/msoap/shell2http) - HTTP-server to execute shell commands. Designed for development, prototyping or remote control.
 - [HTTP Prompt](https://github.com/eliangcs/http-prompt) - An interactive command-line HTTP client featuring autocomplete and syntax highlighting.
+- [npm-check-updates](https://github.com/tjunnone/npm-check-updates) - Find newer versions of package dependencies than what your package.json allows.
+
 
 ### Mobile Development
 


### PR DESCRIPTION
#### New App Submission

**App name:** npm-check-updates

**Repo or homepage link:**[repo](https://github.com/tjunnone/npm-check-updates)

**Description:**
Find newer versions of package dependencies than what your package.json allows

**Why you think it's awesome:**
It's default is a dry run (i.e. it prints out new version that will be upgraded):

```
 jsonwebtoken     ^8.4.0  →     ^8.5.0 
 mongoose        ^5.4.13  →    ^5.4.17 
 @types/helmet    0.0.42  →     0.0.43 
 @types/jest     ^24.0.5  →    ^24.0.9 
 @types/node     ^11.9.4  →   ^11.10.5 
 jest            ^24.1.0  →    ^24.3.1 
 ts-jest        ^23.10.5  →    ^24.0.0 
 ts-node          ^8.0.2  →     ^8.0.3 
 typescript       ^3.3.3  →  ^3.3.3333
```

It allows for exclusion of updates, and is all in all way more predictable than `npm upgrade`. 