### PR TITLE
Add gcalcli

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -211,6 +211,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [Buku](https://github.com/jarun/Buku) - Browser-independent bookmark manager.
 - [googler](https://github.com/jarun/googler) - Google from the terminal.
 - [calcurse](http://calcurse.org/) - A calendar and scheduling application for the command-line.
+- [gcalcli](https://github.com/insanum/gcalcli) – Access your Google calendar from the command-line.
 - [papis](http://github.com/alejandrogallo/papis) - Extensible document and bibliography manager.
 
 ### Time Tracking


### PR DESCRIPTION
Would be added under Productivity (below calcurse)

<!---
Thank you for your pull request. Please provide below the name of the app, a short description 
and a link to it's repository or homepage. Also, tell us why you think it's awesome!

Make sure the PR adheres to our contribution guidelines:
https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md
-->

#### New App Submission

**App name:** gcalcli

**Repo or homepage link:** https://github.com/insanum/gcalcli

**Description:** Access your Google calendar from the terminal.


