### PR TITLE
Add livcricket

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 ## Entertainment
 
 - [football-cli](https://github.com/ManrajGrover/football-cli) - Get live scores, fixtures, standings of almost every football competition/league.
+- [livcricket](https://github.com/shakeabi/livcricket) - Get live scores of almost every cricket match from your terminal (includes notifications).
 - [pockyt](https://github.com/arvindch/pockyt) - Read, Manage, and Automate your [Pocket](https://getpocket.com) collection.
 - [newsboat](https://github.com/newsboat/newsboat) - An extendable RSS feed reader for text terminals.
 


### PR DESCRIPTION
#### New App Submission

**App name:**  livcricket

**Repo or homepage link:**  [github](https://github.com/shakeabi/livcricket)

**Description:** Get live scores of almost every cricket match from your terminal (includes notifications).

**Why you think it's awesome:** I needed this kinda CLI for a long time to use in my office. This way I need not switch to a browser to fetch scores.

