### PR TITLE
Add sqlline

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -167,7 +167,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 - [mycli](https://github.com/dbcli/mycli) - MySQL client with autocompletion and syntax highlighting.
 - [pgcli](https://github.com/dbcli/pgcli) - Postgres client with autocompletion and syntax highlighting.
-- [sqlline](https://github.com/julianhyde/sqlline) - Shell for issuing SQL via JDBC with autocompletion, dialect support, syntax highlighting, multiline.
+- [sqlline](https://github.com/julianhyde/sqlline) -  Shell for issuing SQL via JDBC.
 
 ### Devops
 

--- a/readme.md
+++ b/readme.md
@@ -167,6 +167,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 - [mycli](https://github.com/dbcli/mycli) - MySQL client with autocompletion and syntax highlighting.
 - [pgcli](https://github.com/dbcli/pgcli) - Postgres client with autocompletion and syntax highlighting.
+- [sqlline](https://github.com/julianhyde/sqlline) - Shell for issuing SQL via JDBC with autocompletion, dialect support, syntax highlighting, multiline.
 
 ### Devops
 


### PR DESCRIPTION
#### New App Submission

**App name:**
sqlline
**Repo or homepage link:**
https://github.com/julianhyde/sqlline 
**Description:**
Shell for issuing SQL to relational databases via JDBC 
**Why you think it's awesome:**
Currently it has more than 250 stars and continues growing. It could connect to any db via jdbc driver and not only db (e.g. it could connect to elastic-search, cassandra, splunk, mongo, kafka via apache calcite). It provides autocompletion, syntax highlighting, multiline editing(emacs/vi modes), dialect supports. 
Besides project Readme.md there is also a set of video demos with that at asciinema.org https://github.com/julianhyde/sqlline/wiki/Demos

