### PR TITLE
Add gopass

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -270,10 +270,10 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [getnews.tech](https://github.com/omgimanerd/getnews.tech) - Fetch news headlines from various news outlets.
 - [carbon-now-cli](https://github.com/mixn/carbon-now-cli) - Generate beautiful images of your code.
 - [pass](https://www.passwordstore.org) - Password manager.
+- [gopass](https://github.com/gopasspw/gopass) - Fully-featured password manager.
 - [awesome-finder](https://github.com/mingrammer/awesome-finder) - Search the awesome lists without a browser.
 - [mdv](https://github.com/axiros/terminal_markdown_viewer) - Styled terminal markdown viewer.
 - [shallow-backup](https://github.com/alichtman/shallow-backup) - Git integrated backup tool.
-- [gopass](https://github.com/gopasspw/gopass) - A fully-featured password manager with remote syncing, fuzzy-finding, support for multiple stores, a JSON API, and more.
 
 ### macOS
 

--- a/readme.md
+++ b/readme.md
@@ -273,6 +273,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [awesome-finder](https://github.com/mingrammer/awesome-finder) - Search the awesome lists without a browser.
 - [mdv](https://github.com/axiros/terminal_markdown_viewer) - Styled terminal markdown viewer.
 - [shallow-backup](https://github.com/alichtman/shallow-backup) - Git integrated backup tool.
+- [gopass](https://github.com/gopasspw/gopass) - A fully-featured password manager with remote syncing, fuzzy-finding, support for multiple stores, a JSON API, and more.
 
 ### macOS
 


### PR DESCRIPTION
#### New App Submission

**App name:** gopass

**Repo or homepage link:** https://github.com/gopasspw/gopass

**Description:** gopass is a fully-featured command line password manager written in Go. It has support for teams/remote syncing, multiple stores, fuzzy-finding, a JSON API, and more.

**Why you think it's awesome:** It's similar to the proven `pass` command line app but with many extra features that make is useful, especially if you want your password stores available to multiple users or on multiple computers.

This PR replaces #358.