### PR TITLE
Add spotify-tui

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -93,7 +93,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [musikcube](https://github.com/clangen/musikcube) - Cross-platform, terminal-based music player, audio engine, metadata indexer, and server.
 - [beets](https://github.com/beetbox/beets) - Music library manager and tagger.
 - [playx](https://github.com/NISH1001/playx) - Stream songs/playlists from various sources.
-- [spotify-tui](https://github.com/Rigellute/spotify-tui) - A terminal user interface for Spotify
+- [spotify-tui](https://github.com/Rigellute/spotify-tui) - Spotify client.
 
 ### Social Media
 

--- a/readme.md
+++ b/readme.md
@@ -91,6 +91,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [moc](http://moc.daper.net/) - Console audio player for Linux/UNIX.
 - [musikcube](https://github.com/clangen/musikcube) - Cross-platform, terminal-based music player, audio engine, metadata indexer, and server.
 - [beets](https://github.com/beetbox/beets) - Music library manager and tagger.
+- [spotify-tui](https://github.com/Rigellute/spotify-tui) - A terminal user interface for Spotify
 
 ### Social Media
 


### PR DESCRIPTION
<!---
Thank you for your pull request. Please provide below the name of the app, a short description 
and a link to it's repository or homepage. Also, tell us why you think it's awesome!

Make sure the PR adheres to our contribution guidelines:
https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md
-->

#### New App Submission

**App name:**
spotify-tui
**Repo or homepage link:**
https://github.com/Rigellute/spotify-tui
**Description:**
Terminal user interface for spotify.
**Why you think it's awesome:**
This app offers a fast, lightweight, portable terminal user interface for Spotify. Intended for users that don't want to leave the terminal. 

The app makes use of familiar vim & tmux keybindings.

### Demo
![Demo](https://user-images.githubusercontent.com/12150276/64545371-84af3580-d320-11e9-867d-c368fd888b3b.gif)
