### PR TITLE
add import-github-labels-cli

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -477,7 +477,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [gita](https://github.com/nosarthur/gita) - Manage multiple git repos side by side for sanity.
 - [readme-md-generator](https://github.com/kefranabg/readme-md-generator) - Generate README.md files interactively.
 - [semantic-git-commit-cli](https://github.com/JPeer264/node-semantic-git-commit-cli) - Ensure semantic commits messages.
-- [import-github-labels-cli](https://github.com/abhijithvijayan/import-github-labels-cli) - CLI to import labels from another repository on GitHub
+- [import-github-labels-cli](https://github.com/abhijithvijayan/import-github-labels-cli) - Sync labels between Github repos.
 
 ## Images
 

--- a/readme.md
+++ b/readme.md
@@ -463,6 +463,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [gitlab-cli](https://github.com/vishwanatharondekar/gitlab-cli) - gitlab cli for creating merge request from the command line.
 - [git-extras](https://github.com/tj/git-extras) - Little git extras like git-ignore, git-setup, git-changelog, git-release, git-effort and more.
 - [gita](https://github.com/nosarthur/gita) - Manage multiple git repos side by side for sanity.
+- [import-github-labels-cli](https://github.com/abhijithvijayan/import-github-labels-cli) - CLI to import labels from another repository on GitHub
 
 ## Images
 


### PR DESCRIPTION
<!---
Thank you for your pull request. Please provide below the name of the app, a short description 
and a link to it's repository or homepage. Also, tell us why you think it's awesome!

Make sure the PR adheres to our contribution guidelines:
https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md
-->

#### New App Submission

**App name:** import-github-labels-cli

**Repo or homepage link:** https://github.com/abhijithvijayan/import-github-labels-cli

**Description:** CLI to import labels from another repository on GitHub 

**Why you think it's awesome:** Sometimes when a user needs to import / manage GitHub labels used in one project to another in a single command, this CLI does it neat & perfect.

