### PR TITLE
Add iredis

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -180,6 +180,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [mycli](https://github.com/dbcli/mycli) - MySQL client with autocompletion and syntax highlighting.
 - [pgcli](https://github.com/dbcli/pgcli) - Postgres client with autocompletion and syntax highlighting.
 - [sqlline](https://github.com/julianhyde/sqlline) -  Shell for issuing SQL via JDBC.
+- [iredis](https://github.com/laixintao/iredis) - Interactive Redis: A Terminal Client for Redis with AutoCompletion and Syntax Highlighting.
 
 ### Devops
 

--- a/readme.md
+++ b/readme.md
@@ -180,7 +180,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [mycli](https://github.com/dbcli/mycli) - MySQL client with autocompletion and syntax highlighting.
 - [pgcli](https://github.com/dbcli/pgcli) - Postgres client with autocompletion and syntax highlighting.
 - [sqlline](https://github.com/julianhyde/sqlline) -  Shell for issuing SQL via JDBC.
-- [iredis](https://github.com/laixintao/iredis) - Interactive Redis: A Terminal Client for Redis with AutoCompletion and Syntax Highlighting.
+- [iredis](https://github.com/laixintao/iredis) - Redis client with autocompletion and syntax highlighting.
 
 ### Devops
 


### PR DESCRIPTION


#### New App Submission

- [x] I've read the [contribution guidelines](https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md).

- https://github.com/laixintao/iredis
- https://iredis.io

**Description:**

Interactive Redis: A Terminal Client for Redis with AutoCompletion and Syntax Highlighting.

<img width="806" alt="image" src="https://user-images.githubusercontent.com/9675939/75509878-0c4e4500-5a24-11ea-84cd-44062b65ba82.png">


## Features

- Advanced code completion. If you run command `KEYS` then run `DEL`, IRedis will auto-complete your command based on `KEYS` result.
- Command validation. E.g. try `CLUSTER MEET IP PORT`, iredis will validate IP and PORT for you.
- Command highlighting, fully based on redis grammar. Any valid command in IRedis shell is a valid redis command.
- Human-friendly result display.
- `peek` command to check the key's type then automatically call `get`/`lrange`/`sscan`, etc, depending on types. You don't need to call the `type` command then type another command to get the value. `peek` will also display the key's length and memory usage.
- <kbd>Ctrl</kbd> + <kbd>C</kbd> to cancel the current typed command, this won't exit iredis, exactly like bash behaviour. Use <kbd>Ctrl</kbd> + <kbd>D</kbd> to send a EOF to exit iredis.
- Says "Goodbye!" to you when you exit!
- <kbd>Ctrl</kbd> + <kbd>R</kbd> to open **reverse-i-search** to search through your command history.
- Auto suggestions. (Like [fish shell](http://fishshell.com/).)
- Support `--encode=utf-8`, to decode Redis' bytes responses.
- Command hint on bottom, include command syntax, supported redis version, and time complexity.
- Offcial docs with built-in `HELP` command, try `HELP SET`!
- Written in pure Python, but IRedis was packaged into a single binary with
[PyOxidizer](https://github.com/indygreg/PyOxidizer), you can use cURL to
download and run, it just works, even you don't have a Python interpreter.
- For full features, please see: [iredis.io/show](https://www.iredis.io/show/)

