### PR TITLE
Add docker-pushrm

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -197,6 +197,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [flog](http://github.com/mingrammer/flog) - A fake log generator for log formats such as apache-common, apache error and RFC3164 syslog.
 - [isitfit](http://github.com/autofitcloud/isitfit) - Manage AWS EC2 rightsizing.
 - [docker-shell](https://github.com/Trendyol/docker-shell) - Simple interactive docker interface.
+- [docker-pushrm](https://github.com/christian-korneck/docker-pushrm) - A Docker CLI plugin that that lets you push the README.md file from the current directory to a container registry. Supports Docker Hub, Quay and Harbor.
 
 ### Release
 

--- a/readme.md
+++ b/readme.md
@@ -189,15 +189,18 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [azure-cli](https://github.com/Azure/azure-cli) - Command-line tools for Azure.
 - [SAWS](https://github.com/donnemartin/saws) - Supercharged AWS CLI.
 - [s3cmd](https://github.com/s3tools/s3cmd) - Fully-Featured S3 client.
-- [lstags](https://github.com/ivanilves/lstags) - Synchronize Docker images across different registries.
 - [pm2](https://pm2.io/runtime/) - Production Process Manager for Node.js.
-- [dockly](https://github.com/lirantal/dockly) - Interactively manage Docker containers.
 - [ops](https://github.com/nanovms/ops) - Unikernel compilation and orchestration tool.
-- [lazydocker](https://github.com/jesseduffield/lazydocker) - Simple docker/docker-compose interface.
 - [flog](http://github.com/mingrammer/flog) - A fake log generator for log formats such as apache-common, apache error and RFC3164 syslog.
 - [isitfit](http://github.com/autofitcloud/isitfit) - Manage AWS EC2 rightsizing.
+
+### Docker
+
+- [lstags](https://github.com/ivanilves/lstags) - Synchronize images across registries.
+- [dockly](https://github.com/lirantal/dockly) - Interactively manage containers.
+- [lazydocker](https://github.com/jesseduffield/lazydocker) - Simple docker/docker-compose interface.
 - [docker-shell](https://github.com/Trendyol/docker-shell) - Simple interactive docker interface.
-- [docker-pushrm](https://github.com/christian-korneck/docker-pushrm) - A Docker CLI plugin that that lets you push the README.md file from the current directory to a container registry. Supports Docker Hub, Quay and Harbor.
+- [docker-pushrm](https://github.com/christian-korneck/docker-pushrm) - Push a readme to container registries.
 
 ### Release
 


### PR DESCRIPTION
…ADME.md file from the current directory to a container registry like Docker Hub.


#### New App Submission

- [X] I've read the [contribution guidelines](https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md).

**Repo or homepage link:**
https://github.com/christian-korneck/docker-pushrm

**Description:**
[docker-pushrm](https://github.com/christian-korneck/docker-pushrm) is a Docker CLI plugin that pushes the README file from the current directory to a container registry where it appears as repo description. Supports Docker Hub, Quay Harbor.

**Why you think it's awesome:**

I've always liked that with Docker you can push an image to Docker Hub (or other container registries) even if the repo for it doesn't exist yet (it gets created on the fly).
docker push myuser/myimage:tag
With docker pushrm, a little CLI plugin for Docker, it's now possible to set or update the README of the repo in the same style:

```
$ ls
README.md
$ docker pushrm myuser/myimage
```

It works with Docker Hub, Quay, Harbor.

