### PR TITLE
Added google drive upload to Productivity

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -239,6 +239,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [Buku](https://github.com/jarun/Buku) - Browser-independent bookmark manager.
 - [googler](https://github.com/jarun/googler) - Google from the terminal.
 - [papis](http://github.com/alejandrogallo/papis) - Extensible document and bibliography manager.
+- [google-drive-upload](https://github.com/labbots/google-drive-upload) - Utility to upload/sync files and folders to google drive.
 
 ### Time Tracking
 

--- a/readme.md
+++ b/readme.md
@@ -239,7 +239,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [Buku](https://github.com/jarun/Buku) - Browser-independent bookmark manager.
 - [googler](https://github.com/jarun/googler) - Google from the terminal.
 - [papis](http://github.com/alejandrogallo/papis) - Extensible document and bibliography manager.
-- [google-drive-upload](https://github.com/labbots/google-drive-upload) - Utility to upload/sync files and folders to google drive.
+- [google-drive-upload](https://github.com/labbots/google-drive-upload) - Upload/sync with Google Drive.
 
 ### Time Tracking
 

--- a/readme.md
+++ b/readme.md
@@ -239,7 +239,6 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [Buku](https://github.com/jarun/Buku) - Browser-independent bookmark manager.
 - [googler](https://github.com/jarun/googler) - Google from the terminal.
 - [papis](http://github.com/alejandrogallo/papis) - Extensible document and bibliography manager.
-- [google-drive-upload](https://github.com/labbots/google-drive-upload) - Upload/sync with Google Drive.
 
 ### Time Tracking
 
@@ -428,6 +427,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [ffsend](https://github.com/timvisee/ffsend) - Fully featured CLI for [Firefox Send](https://send.firefox.com/) - simple and private file sharing.
 - [webtorrent-cli](https://github.com/feross/webtorrent-cli) – Streaming torrent client.
 - [share-cli](https://github.com/marionebl/share-cli) - Share files with your local network.
+- [google-drive-upload](https://github.com/labbots/google-drive-upload) - Upload/sync with Google Drive.
 
 ### Directory Listing
 


### PR DESCRIPTION
<!---
Thank you for your pull request. 
Please fill out the fields below and check that
your contribution adheres to our guidelines.
-->

#### New App Submission

- [x] I've read the [contribution guidelines](https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md).

**Repo or homepage link:** 
https://github.com/labbots/google-drive-upload

**Description:**
Google Drive Upload (gupload) is a  cli tool that enables users to upload files and folders to google drive from command line. It also has ability to upload files in parallel and resume interrupted uploads.

**Why you think it's awesome:**
It allows users to upload files and folders to the user's google drive from command line. The script can also be used as part of CI to push artifacts into google drive and share it with anyone.
