### PR TITLE
Add swaglyrics

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -97,6 +97,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [beets](https://github.com/beetbox/beets) - Music library manager and tagger.
 - [playx](https://github.com/NISH1001/playx) - Stream songs/playlists from various sources.
 - [spotify-tui](https://github.com/Rigellute/spotify-tui) - Spotify client.
+- [swaglyrics](https://github.com/SwagLyrics/SwagLyrics-For-Spotify) - Lyrics of the currently playing song in Spotify.
 
 ### Social Media
 

--- a/readme.md
+++ b/readme.md
@@ -97,7 +97,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [beets](https://github.com/beetbox/beets) - Music library manager and tagger.
 - [playx](https://github.com/NISH1001/playx) - Stream songs/playlists from various sources.
 - [spotify-tui](https://github.com/Rigellute/spotify-tui) - Spotify client.
-- [swaglyrics](https://github.com/SwagLyrics/SwagLyrics-For-Spotify) - Lyrics of the currently playing song in Spotify.
+- [swagsyrics-for-spotify](https://github.com/SwagLyrics/SwagLyrics-For-Spotify) - Spotify lyrics.
 
 ### Social Media
 


### PR DESCRIPTION
<!---
Thank you for your pull request. 
Please fill out the fields below and check that
your contribution adheres to our guidelines.
-->

#### New App Submission

- [x] I've read the [contribution guidelines](https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md).

**Repo or homepage link:** https://github.com/SwagLyrics/SwagLyrics-For-Spotify

**Description:**
Fetches the currently playing song from Spotify on Windows, Linux and macOS and displays the lyrics in the command-line, browser tab or in a desktop application. Refreshes automatically when song changes. The lyrics are fetched from Genius. Turns out Deezer already has this feature in-built but with swaglyrics, you can have it in Spotify as well.
wagLyrics is the fastest and the most accurate package for getting lyrics.1

Provided optimal internet, SwagLyrics can fetch lyrics for a track in as less as 0.28s.2

It also does not require the user to generate any sort of API token (Spotify or Genius) and serves functionality right off the bat. This is possible as the song identification is done using our in-house library SwSpotify which does it locally for all operating systems.

The enhanced user experience is possible due to the backend which manages creating issues for unsupported songs and then adding support for them where possible by employing various techniques. Any song with lyrics on Genius can be supported without any user interaction owing to the backend. If say, lyrics do not exist for a track then subsequent playings of that track will not waste your resources in trying to fetch lyrics, this is done by a master list of unsupported songs which is handled by the backend as well.

1. [results] Tested against LyricsGenius, the most popular similar package on the US Top 50 Chart on Spotify. SwagLyrics was fractionally more accurate and 2.4x times faster. ↩
2. [results] Speed and accuracy benchmark using Google Colab on the Spotify US Top 50 chart. ↩

**Why you think it's awesome:**
I don't see other terminal lyrics providers listed here. A lot of people listen to Spotify and the app does not include lyrics of songs so they have to rely on some other source for them. What better than have it in the terminal. I have tried a few but this seems like the fastest and most reliable one.
