### PR TITLE
Add k9s to Devops

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -197,7 +197,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [ops](https://github.com/nanovms/ops) - Unikernel compilation and orchestration tool.
 - [flog](http://github.com/mingrammer/flog) - A fake log generator for log formats such as apache-common, apache error and RFC3164 syslog.
 - [isitfit](http://github.com/autofitcloud/isitfit) - Manage AWS EC2 rightsizing.
-- [k9s](https://github.com/derailed/k9s) - Kubernetes CLI to manage your clusters in style.
+- [k9s](https://github.com/derailed/k9s) - Manage Kubernetes Clusters.
 
 ### Docker
 

--- a/readme.md
+++ b/readme.md
@@ -197,6 +197,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [ops](https://github.com/nanovms/ops) - Unikernel compilation and orchestration tool.
 - [flog](http://github.com/mingrammer/flog) - A fake log generator for log formats such as apache-common, apache error and RFC3164 syslog.
 - [isitfit](http://github.com/autofitcloud/isitfit) - Manage AWS EC2 rightsizing.
+- [k9s](https://github.com/derailed/k9s) - Kubernetes CLI to manage your clusters in style.
 
 ### Docker
 


### PR DESCRIPTION
<!---
Thank you for your pull request. 
Please fill out the fields below and check that
your contribution adheres to our guidelines.
-->

#### New App Submission

- [x] I've read the [contribution guidelines](https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md).

**Repo or homepage link:** https://github.com/derailed/k9s / https://k9scli.io

**Description:** Kubernetes CLI to manage your clusters in style.

**Why you think it's awesome:**
I was surpised not to see k9s in this list, as it's the most impressive CLI app I've ever used !

It's very popular among kubernetes users (11.5k stars), because it's both intuitive and very complete feature-wise

It is also the only CLI tool which can totally replace `kubectl`
