### PR TITLE
Add unix-notes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -270,6 +270,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [Taskwarrior](http://taskwarrior.org) - Manage your TODO list from your command-line.
 - [Terminal velocity](https://vhp.github.io/terminal_velocity/) - A fast note-taking app for the terminal.
 - [eureka](https://github.com/simeg/eureka) - Store your ideas without leaving the terminal.
+- [notes](https://github.com/Standard-Unix-Notes/unix-notes) - GPG Encrypted Notes/Notebook manager for BSD/Linux
 - [sncli](https://github.com/insanum/sncli) - Simplenote client.
 - [td-cli](https://github.com/darrikonn/td-cli) - A TODO manager to organize and manage your TODO's across multiple projects.
 - [taskell](https://github.com/smallhadroncollider/taskell) - Interactive kanban board/task manager.


### PR DESCRIPTION


Hi

I've suggested Standard Unix Notes - a GPG encrypted ntoes/notebook manager that runs in any Unix/BSD/Linux etc that supports GnuPG.

It is written in the Bourne shell avoiding Bash as that is not installed by default on some machines.

<!---
Thank you for your pull request. 
Please fill out the fields below and check that
your contribution adheres to our guidelines.
-->

#### New App Submission

- [X] I've read the [contribution guidelines](https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md).

**Repo or homepage link:**
https://github.com/Standard-Unix-Notes/unix-notes

**Description:**
a GPG encrypted notes/notebook manager
**Why you think it's awesome:**
Only uses Bourne shell and GPG so it's completely platform agnostic. Influenced by password-store
