### PR TITLE
Add "unix notes" to Readme.md in notes section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -275,7 +275,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [taskell](https://github.com/smallhadroncollider/taskell) - Interactive kanban board/task manager.
 - [taskbook](https://github.com/klaussinani/taskbook) - Tasks, boards & notes for the command-line habitat.
 - [dnote](https://github.com/dnote/dnote) - A interactive, multi-device notebook.
-- [notes](https://github.com/Standard-Unix-Notes/unix-notes) - GPG Encrypted Notes/Notebook manager for BSD/Linux
+- [unix notes](https://github.com/Standard-Unix-Notes/unix-notes) - GPG Encrypted Notes/Notebook manager for BSD/Linux
 
 ### Finance
 

--- a/readme.md
+++ b/readme.md
@@ -270,12 +270,12 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [Taskwarrior](http://taskwarrior.org) - Manage your TODO list from your command-line.
 - [Terminal velocity](https://vhp.github.io/terminal_velocity/) - A fast note-taking app for the terminal.
 - [eureka](https://github.com/simeg/eureka) - Store your ideas without leaving the terminal.
-- [notes](https://github.com/Standard-Unix-Notes/unix-notes) - GPG Encrypted Notes/Notebook manager for BSD/Linux
 - [sncli](https://github.com/insanum/sncli) - Simplenote client.
 - [td-cli](https://github.com/darrikonn/td-cli) - A TODO manager to organize and manage your TODO's across multiple projects.
 - [taskell](https://github.com/smallhadroncollider/taskell) - Interactive kanban board/task manager.
 - [taskbook](https://github.com/klaussinani/taskbook) - Tasks, boards & notes for the command-line habitat.
 - [dnote](https://github.com/dnote/dnote) - A interactive, multi-device notebook.
+- [notes](https://github.com/Standard-Unix-Notes/unix-notes) - GPG Encrypted Notes/Notebook manager for BSD/Linux
 
 ### Finance
 

--- a/readme.md
+++ b/readme.md
@@ -270,6 +270,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [Taskwarrior](http://taskwarrior.org) - Manage your TODO list from your command-line.
 - [Terminal velocity](https://vhp.github.io/terminal_velocity/) - A fast note-taking app for the terminal.
 - [eureka](https://github.com/simeg/eureka) - Store your ideas without leaving the terminal.
+- [notes](https://github.com/Standard-Unix-Notes/unix-notes) - GPG Encrypted Notes/Notebook manager for BSD/Linux
 - [sncli](https://github.com/insanum/sncli) - Simplenote client.
 - [td-cli](https://github.com/darrikonn/td-cli) - A TODO manager to organize and manage your TODO's across multiple projects.
 - [taskell](https://github.com/smallhadroncollider/taskell) - Interactive kanban board/task manager.


### PR DESCRIPTION
<!---
Thank you for your pull request. 
Please fill out the fields below and check that
your contribution adheres to our guidelines.
-->

#### New App Submission

- [X] I've read the [contribution guidelines](https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md).

**Repo or homepage link:**
https://github.com/Standard-Unix-Notes/unix-notes

**Description:**
GPG Encrypted Notes/Notebook manager for all Unix-like/Linux OSes

**Why you think it's awesome:**

Unix notes is a simple easy to use command line utility for managing notes and notebooks. Each note is encrypted using GPG to make them secure.  

It was influenced by password-store and other similar utilities in the way it uses sub commands

Why use this tool rather than just GPG by itself?   Unix notes also includes a feature to re-encrypt all your notes with another GPG key, which is particularly useful when your key is about to expire. 


