### PR TITLE
Utilities: add deadlink

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -314,6 +314,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [carbon-now-cli](https://github.com/mixn/carbon-now-cli) - Generate beautiful images of your code.
 - [awesome-finder](https://github.com/mingrammer/awesome-finder) - Search the awesome lists without a browser.
 - [shallow-backup](https://github.com/alichtman/shallow-backup) - Git integrated backup tool.
+- [deadlink](https://github.com/nschloe/deadlink) - Find dead links in files.
 
 ### macOS
 


### PR DESCRIPTION
_Disclaimer:_ I wrote deadlink.

#### New App Submission

- [x] I've read the [contribution guidelines](https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md#readme).

**Repo or homepage link:**
https://github.com/nschloe/deadlink

**Description:**

[deadlink](https://github.com/nschloe/deadlink) finds and fixes dead links (and redirects) in files.

**Why I think it's awesome:**

Does one thing and does it well: Finds dead links in codes files, `README.md`s etc. Running it on this `readme.md` gives
```
Successful permanent redirects (14):
   301:   http://taskwarrior.org
   → 200: https://taskwarrior.org/
   301:   http://calcurse.org/
   → 200: https://calcurse.org/
   301:   https://i.creativecommons.org/p/zero/1.0/88x31.png
   → 200: https://licensebuttons.net/p/zero/1.0/88x31.png
   301:   http://ledger-cli.org
   → 302: https://ledger-cli.org/
   301:   https://www.nongnu.org/renameutils
   → 200: https://www.nongnu.org/renameutils/
   301:   https://github.com/jkbrzt/httpie
   → 200: https://github.com/httpie/httpie
   301:   https://cdn.rawgit.com/aharris88/awesome-cli-apps/master/media/banner.png
   → 200: https://cdn.jsdelivr.net/gh/aharris88/awesome-cli-apps@master/media/banner.png
   301:   https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg
   → 200: https://cdn.jsdelivr.net/gh/sindresorhus/awesome@d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg
   301:   https://nicolargo.github.io/glances
   → 200: https://nicolargo.github.io/glances/
   301:   https://github.com/eliangcs/http-prompt
   → 200: https://github.com/httpie/http-prompt
   301:   http://vicerveza.homeunix.net/~viric/soft/ts
   → 200: http://vicerveza.homeunix.net/~viric/soft/ts/
   301:   http://www.explainshell.com
   → 200: https://www.explainshell.com/
   301:   http://www.bay12games.com/dwarves
   → 200: http://www.bay12games.com/dwarves/
   301:   https://dianne.skoll.ca/projects/remind
   → 200: https://dianne.skoll.ca/projects/remind/
```
Pretty minor, but the change in `http-prompt` is probably significant. Use
```
deadlink rr readme.md
```
to replace the redirects.