### PR TITLE
Add neoss

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -352,6 +352,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [speed-test](https://github.com/sindresorhus/speed-test) - `speedtest-net` wrapper with different UI.
 - [speedtest-cli](https://github.com/sivel/speedtest-cli) - Test internet bandwidth using speedtest.net.
 - [bandwhich](https://github.com/imsnif/bandwhich) - Track bandwidth utilization by process.
+- [neoss](https://github.com/PabloLec/neoss) - User-friendly and detailed socket statistics with a Terminal UI.
 
 ### Theming and Customization
 

--- a/readme.md
+++ b/readme.md
@@ -352,7 +352,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [speed-test](https://github.com/sindresorhus/speed-test) - `speedtest-net` wrapper with different UI.
 - [speedtest-cli](https://github.com/sivel/speedtest-cli) - Test internet bandwidth using speedtest.net.
 - [bandwhich](https://github.com/imsnif/bandwhich) - Track bandwidth utilization by process.
-- [neoss](https://github.com/PabloLec/neoss) - User-friendly and detailed socket statistics with a Terminal UI.
+- [neoss](https://github.com/PabloLec/neoss) - User-friendly and detailed socket statistics.
 
 ### Theming and Customization
 


### PR DESCRIPTION
#### New App Submission

- [x] I've read the [contribution guidelines](https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md#readme).

**Repo or homepage link:** https://github.com/PabloLec/neoss

**Description:** User-friendly and detailed socket statistics with a Terminal UI. (Basically `ss` command but easy to understand)

**Why I think it's awesome:** I made it after spending too much time piping all sort of dark commands to `ss`.
The first purpose was to give `ss` a clear and simple UI. Then it evolved to add other features in order to get more in-depth details on what is exactly using a socket.
For example you can get a port standard attribution, domain name resolution, whois on that domain, who started the process using this socket and with which command. Well you can select anything and get either a human readable explanation and/or more details than a bare `ss`.

