### PR TITLE
Add arttime

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -263,6 +263,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 ### Time Tracking
 
+- [arttime](https://github.com/reportaman/arttime) - Beauty of text art meets functionality of clock, timer, pomodoro++ time manager
 - [Timetrap](https://github.com/samg/timetrap) - Simple timetracker.
 - [moro](https://github.com/omidfi/moro) - Simple tool for tracking work hours.
 - [Timewarrior](https://github.com/GothenburgBitFactory/timewarrior) - Utility with simple stopwatch, calendar-based backfill and flexible reporting.

--- a/readme.md
+++ b/readme.md
@@ -263,13 +263,13 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 ### Time Tracking
 
-- [arttime](https://github.com/reportaman/arttime) - Beauty of text art meets functionality of clock, timer, pomodoro++ time manager
 - [Timetrap](https://github.com/samg/timetrap) - Simple timetracker.
 - [moro](https://github.com/omidfi/moro) - Simple tool for tracking work hours.
 - [Timewarrior](https://github.com/GothenburgBitFactory/timewarrior) - Utility with simple stopwatch, calendar-based backfill and flexible reporting.
 - [Watson](https://github.com/TailorDev/Watson) - Generate reports for clients and manage your time.
 - [utt](https://github.com/larose/utt) - Simple time tracking tool.
 - [Bartib](https://github.com/nikolassv/bartib) - Easy to use time tracking tool.
+- [arttime](https://github.com/reportaman/arttime) - Featureful timer with native desktop notifications and curated ASCII art.
 
 ### Note Taking and Lists
 


### PR DESCRIPTION
<!---
Thank you for your pull request. 
Please fill out the fields below and check that
your contribution adheres to our guidelines.
-->

#### New App Submission

- [x] I've read the [contribution guidelines](https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md#readme).

**Repo or homepage link:** https://github.com/poetaman/arttime

**Description:** Featureful timer with native desktop notifications and curated ASCII art.

**Why I think it's awesome:** Runs with zero dependencies on macOS and minimal dependencies on other OSes. This shell script timer tool brings a dash of curated ASCII / UTF art to developer terminals, while offering functionality of timer. Users can also set a time manager program tailored to their needs such that Pomodoro technique is just one of the multitude of possibilities . Please refer to manual ``arttime -m`` and the github repo for more information and design philosophy.