### PR TITLE
Add mdformat

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -397,6 +397,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [mdv](https://github.com/axiros/terminal_markdown_viewer) - Styled terminal markdown viewer.
 - [glow](https://github.com/charmbracelet/glow) - Styled markdown rendering.
 - [gtree](https://github.com/ddddddO/gtree) - Use markdown to generate directory trees and the directories itself.
+- [mdformat](https://github.com/executablebooks/mdformat) - An opinionated markdown formatter.
 
 ### Security
 


### PR DESCRIPTION
<!---
Thank you for your pull request. 
Please fill out the fields below and check that
your contribution adheres to our guidelines.
-->

#### New App Submission

- [x] I've read the [contribution guidelines](https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md#readme).

**Repo or homepage link:**

- Code https://github.com/executablebooks/mdformat
- Docs https://mdformat.readthedocs.io/en/stable/

**Description:**

Mdformat is an opinionated Markdown formatter that can be used to enforce a consistent style in Markdown files. Mdformat is a Unix-style command-line tool as well as a Python library.

The features/opinions of the formatter include:

- Consistent indentation and whitespace across the board
- Always use ATX style headings
- Move all link references to the bottom of the document (sorted by label)
- Reformat indented code blocks as fenced code blocks
- Use 1. as the ordered list marker if possible, also for noninitial list items

**Why I think it's awesome:**

We've been using it regularly across many repositories for awhile now. It enforces a consistent, readable, commonmark-compliant style, with plugins for extensions (like github-favored markdown). It's opinionated nature settles lots of bikeshedding around formatting also.
