### PR TITLE
Add rawhide

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -565,6 +565,7 @@ See [plaintextaccounting.org](https://plaintextaccounting.org) for a great overv
 - [rare](https://github.com/zix99/rare) - Real-time regex aggregation and analysis.
 - [skim](https://github.com/lotabout/skim) - A general fuzzy finder written in rust, similar to fzf.
 - [ast-grep](https://github.com/ast-grep/ast-grep) - A tool for code structrual search, linting and rewriting.
+- [rawhide](https://github.com/raforg/rawhide) - Find files using pretty C expressions.
 
 ## Version Control
 


### PR DESCRIPTION
#### New App Submission

- [x] I've read the [contribution guidelines](https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md#readme).

**Repo or homepage link:**

https://github.com/raforg/rawhide

https://raf.org/rawhide

**Description:**

Find files using pretty C expressions.

**Why I think it's awesome:**

Disclaimer: I wrote *rawhide* so I am very biased. Use your own judgement. Or just dismiss this.

In the *7th Edition UNIX programmer's manual* (1979), the *find(1)* manual entry has a **BUGS** section which just says:

    The syntax is painful.
 
That fact has never changed and never will. It got standardized so it can't. We all just got used to it. Like Stockholm Syndrome.

Rawhide (*rh*) changes this. It's a breath of fresh air. It can do everything that *GNU find* can do (except `-fstype`), but without the painful syntax that's too ugly to remember. It has a search criteria language based on *C* expressions, and you can define your own functions if you don't like the existing names for things. So if you don't like it, you can change it. But the standard/default search terms are pretty awesome already. It's a pleasure to use.

As well as the usual search criteria that *GNU find* supports (e.g., name, path, symlink target, size, age, permissions, ...), rawhide (*rh*) can also search by file attributes/flags (like immutable, append-only, ...), and Access Control List ("POSIX" ones (for Linux, macOS, Cygwin) or NFSv4 ones (for FreeBSD, Solaris)), and Extended Attributes (names and values), MIME type, and file type (i.e., what would *file(1)* say?), and the contents of the file (like *grep*). And it can output search results in detailed *ls*-like format or in JSON format. And the only regex syntax it supports is *perl* regex (*pcre*) because it's the best.

It's like the love child of *find*, *ls*, *file*, *grep*, *sh*, *C*, and *perl*.

Every time I see a ghastly *find* command offered as the answer to a question on stackexchange or similar, I can always see a much much shorter *rh* alternative that's clearer and easier to understand (and easily fits on a line).

I'm delighted that I've written this, because it's so much fun to use, and because I know I'll never need to use *find* again.