### PR TITLE
docs(Productivity): add hygg a minimalistic tui document reader

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -256,6 +256,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 - [doing](https://github.com/ttscoff/doing/) - Keep track of what you’re doing and track what you’ve done.
 - [ffscreencast](https://github.com/cytopia/ffscreencast) - A ffmpeg screencast with video overlay and multi monitor support.
+- [hygg](https://github.com/kruserr/hygg) - 📚 Simplifying the way you read. Minimalistic Vim-like TUI document reader.
 - [meetup-cli](https://github.com/specious/meetup-cli) - Meetup.com client.
 - [NeoMutt](https://neomutt.org) - Email client.
 - [terjira](https://github.com/keepcosmos/terjira) - Jira client.


### PR DESCRIPTION
<!---
Thank you for your pull request. 
Please fill out the fields below and check that
your contribution adheres to our guidelines.
-->

#### New App Submission

- [x] I've read the [contribution guidelines](https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md#readme).

**Repo or homepage link:**
https://github.com/kruserr/hygg

**Description:**
Minimalistic Vim-like TUI document reader.
It is built with the pipeline architecture so individual components of it can be reused, such as the converters, e.g. pdf or epub, or the justifier, as standalone unix cli utilities.

**Why I think it's awesome:**
Genuinely helped me read 1463 pages in 1 year since I started the project.
Has also helped other projects with the justifier implementation.
I imagine that other projects can recompose the components into something even cooler.