### PR TITLE
Add FutureOS

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -859,6 +859,7 @@ Inclusion criteria are less strict for this fast-moving field.
 - [aye-chat](https://github.com/acrotron/aye-chat) - Workspace for editing, running commands, and chatting with your codebase.
 - [cmd-ai](https://github.com/BrodaNoel/cmd-ai) - Turns natural language into executable shell commands.
 - [lilbee](https://github.com/tobocop2/lilbee) - Use local models to talk to your files, code, and more.
+- [FutureOS](https://github.com/futuregene/future-os) - One agent across terminal, desktop, mobile, and IM bots, with approval-gated tools and 3,800+ models.
 
 ## Other Resources
 


### PR DESCRIPTION
Adds [FutureOS](https://github.com/futuregene/future-os) to the **Development → LLM Interaction** category.

One agent across terminal, desktop, mobile, and IM bots, with approval-gated tools and 3,800+ models. MIT + Apache-2.0, 4 months old, 50 stars.